### PR TITLE
Mancano i dati dei giorni 07-03-2020 e 08-03-2020 nella Directory COVID-19/dati-json/dpc-covid19-ita-province.json

### DIFF
--- a/.github/ISSUE_TEMPLATE/errore.md
+++ b/.github/ISSUE_TEMPLATE/errore.md
@@ -1,10 +1,8 @@
 ---
-name: Segnalazione errore (ITA)
+name: Mancanza visualizzazione dei dati nella directory COVID-19/dati-json/dpc-covid19-ita-province.json dei giorni 07/03/2020 e 08/03/2020
 about: Segnalare un errore o mancanza nella documentazione o dati. Utilizzate questo template se volete comunicare in Italiano
 ---
 
-<!--
-Grazie per aver mostrato interesse in questo repo.
 
 Si ricorda che questo repo è mantenuto da un numero ristretto di persone
 
@@ -14,17 +12,17 @@ Da sapere prima di segnalare errori:
 
 Tipo di issue:
 
-- [ ] Dati mancanti o errati <!-- file relativo -->
+- [X] Dati mancanti <!-- file relativo -->
 - [ ] Errore nella documentazione <!-- file relativo -->
 - [ ] Errore or mancanza nella dashboard <!-- file relativo -->
 - [ ] Problemi di visualizzazione nella dashboard <!-- file relativo -->
 
 ## Riassunto
 
-<!-- Scrivi qui la descrizione dell'errore, con riferimento a set di dati oppure documento specifico. -->
+Nella directory COVID-19/dati-json/dpc-covid19-ita-province.json i dati sono aggiornati fino al 06-03-2020 mancano quelli dei giorni successivi (07/03/2020, 08/03/2020)
 
 **Attesa:**
 
-<!-- Quali dati o documentazioni è atteso? -->
+Mancano i dati del 07-03-2020, 08-03-2020
 
-**Attuale:** <!-- Quali dati o documentazione è effetivamente presente (o mancante)? -->
+**Attuale:** Sono visualizzabili i dati fino al 06-03-2020


### PR DESCRIPTION
Directory COVID-19/dati-json/dpc-covid19-ita-province.json