### PR TITLE
Specify the correct date format in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ COVID-19/
 
 | Nome campo                  | Descrizione                       | Description                            | Formato                       | Esempio             |
 |-----------------------------|-----------------------------------|----------------------------------------|-------------------------------|---------------------|
-| **data**                        | Data dell’informazione            | Date of notification                   | YYYY-MM-DD HH:MM:SS (ISO 8601) Ora italiana | 2020-03-05 12:15:45 |
+| **data**                        | Data dell’informazione            | Date of notification                   | YYYY-MM-DD HH:MM:SS (RFC 3339) Ora italiana | 2020-03-05 12:15:45 |
 | **stato**                       | Stato di riferimento              | Country of reference                   | XYZ (ISO 3166-1 alpha-3)      | ITA                 |
 | **codice_regione**              | Codice della Regione (ISTAT 2019) | Code of the Region (ISTAT 2019)        | Numero                        | 13                  |
 | **denominazione_regione**       | Denominazione della Regione       | Name of the Region                     | Testo                         | Abruzzo             |
@@ -92,7 +92,7 @@ COVID-19/
 
 | Nome campo              | Descrizione                         | Description                     | Formato            | Esempio              |
 |-------------------------|-------------------------------------|---------------------------------|--------------------|----------------------|
-| **data**                    | Data dell’informazione              | Date of notification            | YYYY-MM-DD HH:MM:SS (ISO 8601) Ora italiana           | 2020-03-05 12:15:45 |                   |
+| **data**                    | Data dell’informazione              | Date of notification            | YYYY-MM-DD HH:MM:SS (RFC 3339) Ora italiana           | 2020-03-05 12:15:45 |                   |
 | **stato**                   | Stato di riferimento                | Country of reference            | ISO 3166-1 alpha-3 | ITA                  |
 | **codice_regione**          | Codice della Regione (ISTAT 2019)   | Code of the Region (ISTAT 2019) | Numero             | 13                   |
 | **denominazione_regione**   | Denominazione della Regione         | Name of the Region              | Testo              | Abruzzo              |
@@ -120,7 +120,7 @@ COVID-19/
 
 | Nome campo                  | Descrizione                       | Description                            | Formato                       | Esempio             |
 |-----------------------------|-----------------------------------|----------------------------------------|-------------------------------|---------------------|
-| **data**                        | Data dell’informazione            | Date of notification                   | YYYY-MM-DD HH:MM:SS (ISO 8601) Ora italiana | 2020-03-05 12:15:45 |
+| **data**                        | Data dell’informazione            | Date of notification                   | YYYY-MM-DD HH:MM:SS (RFC 3339) Ora italiana | 2020-03-05 12:15:45 |
 | **stato**                       | Stato di riferimento              | Country of reference                   | XYZ (ISO 3166-1 alpha-3)      | ITA                 |
 | **ricoverati_con_sintomi**      | Ricoverati con sintomi            | Hospitalised patients with symptoms    | Numero                        | 3                   |
 | **terapia_intensiva**           | Ricoverati in terapia intensiva   | Intensive Care                         | Numero                        | 3                   |
@@ -132,7 +132,6 @@ COVID-19/
 | **deceduti**                    | Persone decedute                  | Death                                  | Numero                        | 3                   |
 | **totale_casi**                 | Totale casi positivi              | Total amount of positive cases         | Numero                        | 3                   |
 | **tamponi**                     | Totale tamponi                    | Tests performed                        | Numero                        | 3                   |
-
 
 
 *Viene messo a disposizione un file JSON complessivo di tutte le date nella cartella "dati-json": dpc-covid19-ita-andamento-nazionale.json*


### PR DESCRIPTION
Nitpick: the date format is RFC 3339. Plain ISO 8601 doesn't allow for
spaces.