### PR TITLE
Fix badges su README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 # Dati COVID-19 Italia
 
-[![GitHub license](https://img.shields.io/github/license/pcm-dpc/COVID-19)](https://github.com/pcm-dpc/COVID-19/blob/master/license)
-[![GitHub commit](https://img.shields.io/github/last-commit/pcm-dpc/COVID-19)](https://img.shields.io/github/last-commit/pcm-dpc/COVID-19)
+[![GitHub license](https://img.shields.io/badge/License-Creative%20Commons%20Attribution%204.0%20International-blue)](https://github.com/pcm-dpc/COVID-19/blob/master/LICENSE)
+[![GitHub commit](https://img.shields.io/github/last-commit/pcm-dpc/COVID-19)](https://github.com/pcm-dpc/COVID-19/commits/master)
 
 [Sito del Dipartimento della Protezione Civile - Emergenza Coronavirus: la risposta nazionale](http://www.protezionecivile.it/attivita-rischi/rischio-sanitario/emergenze/coronavirus)
 


### PR DESCRIPTION
Ciao,
ho sistemato le badge del README che avevano alcuni problemi. Nel dettaglio:

- **badge licenza**, il link tornava un 404, ora punta correttamente alla licenza. La licenza non viene riconosciuta correttamente da GitHub perchè non è tra quelle supportate. Per questo motivo ho sostituito l'immagine con una statica.
- **badge ultima commit**, il link apriva l'immagine, ora punta alla pagina delle commit.

Fatemi sapere se ci sono problemi e se posso aiutare in altri modi e grazie per il vostro lavoro