### PR TITLE
Statistiche singole province

### DIFF
--- a/scripts/stats_province.py
+++ b/scripts/stats_province.py
@@ -1,0 +1,82 @@
+
+import sys
+import json
+from pprint import pprint
+from matplotlib import pyplot as plt
+
+# Path of the .json dataset by provincia
+DATA_FPATH = "../dati-json/dpc-covid19-ita-province.json"
+
+
+
+if len(sys.argv) <= 1:
+	print(" [ITA] Grafica l'andamento e l'incremento dei casi positivi per le provincie specificate")
+	print(" [ENG] Plots the number and the increment of positive cases for the requested provices")
+	print(f"\tUsage: {sys.argv[0]} provincia1 provincia2 ...")
+	print(f"\texample: {sys.argv[0]} MI RM VE")
+	exit(1)
+
+# Retrieve the input provinces as args, transform to uppercase 
+provinces_input = list(
+	map(str.upper, sys.argv[1:])
+)
+
+
+
+# Load .json province data
+with open(DATA_FPATH) as f:
+    data = json.load(f)
+
+# Create a set of available provinces
+provinces = set([x["sigla_provincia"].upper() for x in data])
+
+# Check if the requested provinces are in the data, otherwise throw an error
+for prov in provinces_input:
+	if not prov in provinces:
+		print(f"Error: bad province {prov}")
+		exit(1)
+
+
+
+# Loop over requested provinces and plot positive cases and increment
+for prov in provinces_input:
+	# Filter only requested area
+	data_prov = list(
+	    filter(lambda x: x["sigla_provincia"]==prov, data)
+	)
+
+	# Extract the positive cases
+	positives = [x["totale_casi"] for x in data_prov]
+	# Remove null elements if present
+	#positives = [x if x != None else 0 for x in positives]
+
+	# Calculate the increment of positive cases day by day
+	increments = [positives[0]]
+	for i in range(1, len(positives)):
+	    increments.append(positives[i] - positives[i-1])
+
+	# Extract the dates (format MM-DD)
+	dates = [x["data"].split(" ")[0][5:] for x in data_prov]
+
+
+	# Plot positive cases
+	positives_plot = plt.figure(1)
+	plt.title("Casi Positivi")
+	plt.plot(dates, positives, label=prov)
+	plt.legend()
+	step = 2
+	plt.xticks(dates[(len(dates)%step)-1::step])
+	# horizontal line on the highest value if there are different provinces
+	if len(provinces_input) > 1:
+		plt.hlines(max(positives), 0, len(dates)-1, "darkred", "--", linewidth=1)
+
+	# Plot increments
+	increments_plot = plt.figure(2)
+	plt.title("Incremento Giornaliero Positivi")
+	plt.plot(dates, increments, label=prov)
+	plt.legend()
+	step = 2
+	plt.xticks(dates[(len(dates)%step)-1::step])
+
+# Finally show the data
+plt.show()

--- a/scripts/stats_province.py
+++ b/scripts/stats_province.py
@@ -24,7 +24,7 @@ provinces_input = list(
 
 
 # Load .json province data
-with open(DATA_FPATH) as f:
+with open(DATA_FPATH, encoding="utf-8-sig") as f:
     data = json.load(f)
 
 # Create a set of available provinces


### PR DESCRIPTION
Salve a tutti.

Ho caricato uno script che permette di vedere l'andamento dei casi e l'incremento degli stessi rispetto ad una o più province.

```
cd scripts
python stats_province.py MI
```

![MI_positives](https://user-images.githubusercontent.com/23057237/76664046-53d7e380-6583-11ea-8925-65567059cdc2.png)

![MI_increments](https://user-images.githubusercontent.com/23057237/76664063-5cc8b500-6583-11ea-8e00-c017da757ca0.png)



E' anche possibile graficare più province alla volta per vedere di quanti giorni una provincia è in "ritardo" rispetto ad un'altra.

```
python stats_province.py MI RM VE
```

![MI_RM_VE_positives](https://user-images.githubusercontent.com/23057237/76664070-60f4d280-6583-11ea-8f96-a1654539da1b.png)

![MI_RM_VE_increments](https://user-images.githubusercontent.com/23057237/76664077-63efc300-6583-11ea-96c8-8fc69748eec2.png)


Lo script è stato fatto abbastanza di corsa però è documentato e sembra funzionare. Richiede Python 3.6+.


Grazie per il vostro lavoro che ci tiene sempre aggiornati sulla situazione.