### PR TITLE
Removed extra double quotation from integer

### DIFF
--- a/dati-json/dpc-covid19-ita-andamento-nazionale-latest.json
+++ b/dati-json/dpc-covid19-ita-andamento-nazionale-latest.json
@@ -10,7 +10,7 @@
         "nuovi_attualmente_positivi": 1648,
         "dimessi_guariti": 14620,
         "deceduti": 11591,
-        "totale_casi": "101739",
+        "totale_casi": 101739,
         "tamponi": 477359,
         "note_it": "",
         "note_en": ""

--- a/dati-json/dpc-covid19-ita-andamento-nazionale.json
+++ b/dati-json/dpc-covid19-ita-andamento-nazionale.json
@@ -570,7 +570,7 @@
         "nuovi_attualmente_positivi": 1648,
         "dimessi_guariti": 14620,
         "deceduti": 11591,
-        "totale_casi": "101739",
+        "totale_casi": 101739,
         "tamponi": 477359,
         "note_it": "",
         "note_en": ""


### PR DESCRIPTION
the "totale_casi" is an integer and was always treated as so in the JSON files, in the last update for today it was considered as string so i removed the double quotation to treat it as integer back