### PR TITLE
correct dataset bolzano

### DIFF
--- a/dati-province/dpc-covid19-ita-province-20201007.csv
+++ b/dati-province/dpc-covid19-ita-province-20201007.csv
@@ -78,7 +78,7 @@ data,stato,codice_regione,denominazione_regione,codice_provincia,denominazione_p
 2020-10-07T17:00:00,ITA,14,Molise,094,Isernia,IS,41.58800826,14.22575407,105,
 2020-10-07T17:00:00,ITA,14,Molise,890,Fuori Regione / Provincia Autonoma,,,,22,
 2020-10-07T17:00:00,ITA,14,Molise,990,In fase di definizione/aggiornamento,,,,0,
-2020-10-07T17:00:00,ITA,04,P.A. Bolzano,021,Bolzano,BZ,46.49933453,11.35662422,0,
+2020-10-07T17:00:00,ITA,04,P.A. Bolzano,021,Bolzano,BZ,46.49933453,11.35662422,3734,
 2020-10-07T17:00:00,ITA,04,P.A. Bolzano,881,Fuori Regione / Provincia Autonoma,,,,0,
 2020-10-07T17:00:00,ITA,04,P.A. Bolzano,981,In fase di definizione/aggiornamento,,,,0,
 2020-10-07T17:00:00,ITA,04,P.A. Trento,022,Trento,TN,46.06893511,11.12123097,6296,

--- a/dati-province/dpc-covid19-ita-province.csv
+++ b/dati-province/dpc-covid19-ita-province.csv
@@ -31190,7 +31190,7 @@ data,stato,codice_regione,denominazione_regione,codice_provincia,denominazione_p
 2020-10-07T17:00:00,ITA,14,Molise,094,Isernia,IS,41.58800826,14.22575407,105,
 2020-10-07T17:00:00,ITA,14,Molise,890,Fuori Regione / Provincia Autonoma,,,,22,
 2020-10-07T17:00:00,ITA,14,Molise,990,In fase di definizione/aggiornamento,,,,0,
-2020-10-07T17:00:00,ITA,04,P.A. Bolzano,021,Bolzano,BZ,46.49933453,11.35662422,0,
+2020-10-07T17:00:00,ITA,04,P.A. Bolzano,021,Bolzano,BZ,46.49933453,11.35662422,3734,
 2020-10-07T17:00:00,ITA,04,P.A. Bolzano,881,Fuori Regione / Provincia Autonoma,,,,0,
 2020-10-07T17:00:00,ITA,04,P.A. Bolzano,981,In fase di definizione/aggiornamento,,,,0,
 2020-10-07T17:00:00,ITA,04,P.A. Trento,022,Trento,TN,46.06893511,11.12123097,6296,


### PR DESCRIPTION
Dato ufficiale provincia: http://www.provincia.bz.it/sicurezza-protezione-civile/protezione-civile/dati-attuali-sul-coronavirus.asp